### PR TITLE
Fixes error argv is not defined when running

### DIFF
--- a/purl
+++ b/purl
@@ -4,6 +4,7 @@
 
 import requests
 import os
+import sys
 
 CA_CERT='/etc/rhsm/ca/redhat-uep.pem'
 ENTITLEMENT_DIR = '/etc/pki/entitlement'
@@ -18,7 +19,7 @@ def find_client_certpairs(where = ENTITLEMENT_DIR):
     pempairs = [ (c,c+'-key') for c in pemcerts if c+'-key' in pemkeys ]
     return pempairs
 
-URL = argv[-1]
+URL = sys.argv[-1]
 
 certpairs = find_client_certpairs()
 multi_pairs = len(certpairs) > 1


### PR DESCRIPTION
Original script was returning errors like this:

# ./purl https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/optional/os/repodata/repomd.xml
Traceback (most recent call last):
  File "./purl", line 21, in <module>
    URL = argv[-1]
NameError: name 'argv' is not defined

With this changes, it doesn't happen anymore.
